### PR TITLE
Enhance robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 <br />
 <p align="center">
-Install Ruliname: <a href="todo">Microsoft Edge</a> | <a href="todo">Google Chrome</a>
+Install Ruliname: <a href="todo">Microsoft Edge</a> | <a href="https://chromewebstore.google.com/detail/ruliname/hdccmjlkfjhjedgoeckpalmlabdcmfeo">Google Chrome</a>
 <br /><br />
 </p>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ruliname",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A Chromium extension that automatically renames tabs based on predefined rules",
     "type": "module",
     "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -28,7 +28,8 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (rule) {
         chrome.tabs.sendMessage(tabId, {
             type: rule.renameDefinition.type,
-            value: rule.renameDefinition.value
+            value: rule.renameDefinition.value,
+            timeout: 15000,
         });
     }
 });

--- a/src/content.js
+++ b/src/content.js
@@ -1,50 +1,83 @@
 import { RuleType } from './consts.js';
 
-chrome.runtime.onMessage.addListener((renameDefinition, _sender, sendResponse) => {
-    var newTitle = null;
-    switch (renameDefinition.type) {
-        case RuleType.Fixed:
-            newTitle = renameDefinition.value;
-            break;
-        case RuleType.ElementId:
-            try {
-                newTitle = document.getElementById(renameDefinition.value).innerHTML;
-            } catch(_) {
-                console.log(`Failed retreiving element '${renameDefinition.value}' value`);
-            }
+chrome.runtime.onMessage.addListener((renameRequest, _sender, sendResponse) => {
+    getRequestedElement(renameRequest)
+        .then((element) => {
+            console.log('Found requested element');
+            const newTitle = element.innerHTML;
+            document.title = newTitle;
 
-            break;
-        case RuleType.ClassId:
-            try {
-                newTitle = document.querySelector(`.${renameDefinition.value}`).innerHTML;
-            } catch(_) {
-                console.log(`Failed retreiving class '${renameDefinition.value}' value`);
-            }
+            let titleObserver = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.type != 'childList') {
+                        return;
+                    }
 
-            break;
-        default:
-            console.log(`Internal error: unsupported renameDefinition `
-                         + `'type': ${renameDefinition.type}`);
-    }
+                    if (document.title !== newTitle) {
+                        document.title = newTitle;
+                    }
+                });
+            });
 
-    if (newTitle === null) {
-        sendResponse({ result: "fail" });
-        return;
-    }
+            titleObserver.observe(document.querySelector('title'), {
+                childList: true
+            });
 
-    document.title = newTitle;
-    let observer = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-            if (mutation.type != 'childList') {
-                return;
-            }
-
-            if (document.title !== newTitle) {
-                document.title = newTitle;
-            }
+            sendResponse({ result: "ok" });
+        })
+        .catch((error) => {
+            console.warn(error);
+            sendResponse({ result: "fail" });
         });
-    });
-
-    observer.observe(document.querySelector('title'), { childList: true });
-    sendResponse({ result: "ok" });
 });
+
+function getRequestedElement(renameRequest) {
+    return new Promise((resolve, reject) => {
+        function getElement(renameRequest) {
+            switch (renameRequest.type) {
+                case RuleType.Fixed:
+                    const newElement = document.createElement('section');
+                    newElement.textContent = renameRequest.value;
+                    return newElement;
+                case RuleType.ElementId:
+                    return document.getElementById(renameRequest.value);
+                case RuleType.ClassId:
+                    return document.querySelector(`[class="${renameRequest.value}"]`);
+                default:
+                    console.log(`Internal error: unsupported renameDefinition `
+                                + `'type': ${renameRequest.type}`);
+                    return null;
+            }
+        }
+
+        const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.type != 'childList' && mutation.type === 'subtree') {
+                    return;
+                }
+
+                const element = getElement(renameRequest);
+                if (element) {
+                    observer.disconnect();
+                    resolve(element);
+                }
+            });
+        });
+
+        const initialElement = getElement(renameRequest);
+        if (initialElement) {
+            resolve(initialElement);
+            return;
+        }
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+
+        setTimeout(() => {
+            observer.disconnect();
+            reject(new Error('Element not found within timeout period'));
+        }, renameRequest.timeout);
+    });
+}

--- a/src/content.js
+++ b/src/content.js
@@ -1,44 +1,43 @@
 import { RuleType } from './consts.js';
 
 chrome.runtime.onMessage.addListener((renameRequest, _sender, sendResponse) => {
-    getRequestedElement(renameRequest)
-        .then((element) => {
-            console.log('Found requested element');
-            const newTitle = element.innerHTML;
-            document.title = newTitle;
+    getRequestedElement(renameRequest).then((element) => {
+        console.log('Found requested element');
+        const newTitle = element.innerHTML;
+        document.title = newTitle;
 
-            let titleObserver = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    if (mutation.type != 'childList') {
-                        return;
-                    }
+        let titleObserver = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.type != 'childList') {
+                    return;
+                }
 
-                    if (document.title !== newTitle) {
-                        document.title = newTitle;
-                    }
-                });
+                if (document.title !== newTitle) {
+                    document.title = newTitle;
+                }
             });
-
-            titleObserver.observe(document.querySelector('title'), {
-                childList: true
-            });
-
-            sendResponse({ result: "ok" });
-        })
-        .catch((error) => {
-            console.warn(error);
-            sendResponse({ result: "fail" });
         });
+
+        titleObserver.observe(document.querySelector('title'), {
+            childList: true
+        });
+
+        sendResponse({ result: "ok" });
+    }).catch((error) => {
+        console.warn(error);
+        sendResponse({ result: "fail" });
+    });
 });
 
 function getRequestedElement(renameRequest) {
     return new Promise((resolve, reject) => {
         function getElement(renameRequest) {
             switch (renameRequest.type) {
-                case RuleType.Fixed:
+                case RuleType.Fixed: {
                     const newElement = document.createElement('section');
                     newElement.textContent = renameRequest.value;
                     return newElement;
+                }
                 case RuleType.ElementId:
                     return document.getElementById(renameRequest.value);
                 case RuleType.ClassId:

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Ruliname",
     "short_name": "Ruliname",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "manifest_version": 3,
     "default_locale": "en",
     "description": "A Chromium extension that automatically renames tabs based on predefined rules",

--- a/src/rules.js
+++ b/src/rules.js
@@ -1,3 +1,4 @@
+import 'urlpattern-polyfill';
 import { RuleType } from './consts.js';
 
 export class RenameDefinition {

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -174,7 +174,6 @@ describe('Test extension background service', () => {
             js: ["content.js"],
         }])).to.be.true;
 
-
         expect(listenerStub.calledOnce).to.be.true;
 
         const callback = listenerStub.getCall(0).args[0];
@@ -185,6 +184,7 @@ describe('Test extension background service', () => {
         expect(chrome.tabs.sendMessage.calledOnceWithExactly("tabId", {
             type: "fixed",
             value: "val",
+            timeout: 15000,
         })).to.be.true;
     });
 });

--- a/tests/content.test.js
+++ b/tests/content.test.js
@@ -36,94 +36,114 @@ describe('Test title rename content script', () => {
         addListenerCallback = chrome.runtime.onMessage.addListener.getCall(0).args[0];
     });
 
-    it('should respond with fail on unsupported type', () => {
-        const renameDefinition = { type: 'UnsupportedType', value: 'Unsupported Value' };
+    it('should respond with fail on unsupported type', (done) => {
+        const renameRequest = {
+            type: 'UnsupportedType',
+            value: 'Unsupported Value',
+            timeout: 10
+        };
+
         const sendResponse = sinon.spy();
 
-        addListenerCallback(renameDefinition, null, sendResponse);
-        expect(sendResponse.calledWith({ result: 'fail' })).to.be.true;
+        addListenerCallback(renameRequest, null, sendResponse);
+        setTimeout(() => {
+            expect(sendResponse.calledWith({ result: 'fail' })).to.be.true;
+            done();
+        }, 20);
     });
 
-    it('should set document.title to a fixed value', () => {
-        const renameDefinition = { type: RuleType.Fixed, value: 'FixedTitle' };
+    it('should set document.title to a fixed value', (done) => {
+        const renameRequest = { type: RuleType.Fixed, value: 'FixedTitle', timeout: 10 };
         const sendResponse = sinon.spy();
 
-        addListenerCallback(renameDefinition, null, sendResponse);
-
-        expect(document.title).to.equal('FixedTitle');
-        expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+        addListenerCallback(renameRequest, null, sendResponse);
+        setTimeout(() => {
+            expect(document.title).to.equal('FixedTitle');
+            expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+            done();
+        }, 20);
     });
 
-    it('should set document.title to element ID content', () => {
+    it('should set document.title to element ID content', (done) => {
         const element = document.createElement('div');
         element.id = 'elementId';
         element.innerHTML = 'ElementIDTitle';
         document.body.appendChild(element);
 
-        const renameDefinition = { type: RuleType.ElementId, value: 'elementId' };
+        const renameRequest = { type: RuleType.ElementId, value: 'elementId', timeout: 10 };
         const sendResponse = sinon.spy();
 
-        addListenerCallback(renameDefinition, null, sendResponse);
-
-        expect(document.title).to.equal('ElementIDTitle');
-        expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+        addListenerCallback(renameRequest, null, sendResponse);
+        setTimeout(() => {
+            expect(document.title).to.equal('ElementIDTitle');
+            expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+            done();
+        }, 20);
     });
 
-    it('should fail when element ID does not exist', () => {
+    it('should fail when element ID does not exist', (done) => {
         const element = document.createElement('div');
         element.id = 'elementId';
         element.innerHTML = 'ElementIDTitle';
         document.body.appendChild(element);
 
-        const renameDefinition = { type: RuleType.ElementId, value: 'invalidId' };
+        const renameRequest = { type: RuleType.ElementId, value: 'invalidId', timeout: 10 };
         const sendResponse = sinon.spy();
 
-        addListenerCallback(renameDefinition, null, sendResponse);
-        expect(sendResponse.calledWith({ result: 'fail' })).to.be.true;
+        addListenerCallback(renameRequest, null, sendResponse);
+        setTimeout(() => {
+            expect(sendResponse.calledWith({ result: 'fail' })).to.be.true;
+            done();
+        }, 20);
     });
 
-    it('should set document.title to class content', () => {
+    it('should set document.title to class content', (done) => {
         const element = document.createElement('div');
         element.className = 'classId';
         element.innerHTML = 'Class ID Title';
         document.body.appendChild(element);
 
-        const renameDefinition = { type: RuleType.ClassId, value: 'classId' };
+        const renameRequest = { type: RuleType.ClassId, value: 'classId', timeout: 10 };
         const sendResponse = sinon.spy();
 
-        addListenerCallback(renameDefinition, null, sendResponse);
-
-        expect(document.title).to.equal('Class ID Title');
-        expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+        addListenerCallback(renameRequest, null, sendResponse);
+        setTimeout(() => {
+            expect(document.title).to.equal('Class ID Title');
+            expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+            done();
+        }, 20);
     });
 
-    it('should fail when class ID is invalid', () => {
+    it('should fail when class ID is invalid', (done) => {
         const element = document.createElement('div');
         element.className = 'classId';
         element.innerHTML = 'Class ID Title';
         document.body.appendChild(element);
 
-        const renameDefinition = { type: RuleType.ClassId, value: 'invalidClass' };
+        const renameRequest = { type: RuleType.ClassId, value: 'invalidClass', timeout: 10 };
         const sendResponse = sinon.spy();
 
-        addListenerCallback(renameDefinition, null, sendResponse);
-        expect(sendResponse.calledWith({ result: 'fail' })).to.be.true;
+        addListenerCallback(renameRequest, null, sendResponse);
+        setTimeout(() => {
+            expect(sendResponse.calledWith({ result: 'fail' })).to.be.true;
+            done();
+        }, 20);
     });
 
     it('should update document.title when the title element is mutated', (done) => {
-        const renameDefinition = { type: RuleType.Fixed, value: 'Observed Title' };
+        const renameRequest = { type: RuleType.Fixed, value: 'Observed Title', timeout: 10 };
         const sendResponse = sinon.spy();
 
-        addListenerCallback(renameDefinition, null, sendResponse);
+        addListenerCallback(renameRequest, null, sendResponse);
 
-        expect(document.title).to.equal('Observed Title');
-        expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+        setTimeout(() => {
+            expect(document.title).to.equal('Observed Title');
+            expect(sendResponse.calledWith({ result: 'ok' })).to.be.true;
+        }, 100);
 
-        // Simulate a mutation in the title element
         const titleElement = document.querySelector('title');
         titleElement.textContent = 'New Mutated Title';
 
-        // Use a small timeout to allow the MutationObserver to react
         setTimeout(() => {
             expect(document.title).to.equal('Observed Title');
             done();


### PR DESCRIPTION
When applying injected content script, listen for the document body changes for a duration limited by timeout. The resolution of the title value can occur during this timeout. This allows supporting pages that the DOM is loaded before all the data and elements fully load.